### PR TITLE
Patch infinite loop in flush code

### DIFF
--- a/DFRobot_IICSerial.cpp
+++ b/DFRobot_IICSerial.cpp
@@ -186,7 +186,13 @@ size_t DFRobot_IICSerial::read(void *pBuf, size_t size){
 }
 void DFRobot_IICSerial::flush(void){
   sFsrReg_t fsr = readFIFOStateReg();
-  while(fsr.tDat == 1);
+  uint32_t start = millis();
+  while (millis() - start < IICSERIAL_FLUSH_TIMEOUT) {
+    sFsrReg_t fsr = readFIFOStateReg();
+    if (fsr.tDat != 1) {
+      break;
+    }
+  }
 }
 
 

--- a/DFRobot_IICSerial.h
+++ b/DFRobot_IICSerial.h
@@ -35,6 +35,10 @@
 #define DBG(...)
 #endif
 
+#if !defined(IICSERIAL_FLUSH_TIMEOUT)
+#define IICSERIAL_FLUSH_TIMEOUT 8
+#endif
+
 #if !defined(SERIAL_RX_BUFFER_SIZE)
 #if ((RAMEND - RAMSTART) < 1023)
 #define SERIAL_RX_BUFFER_SIZE 16


### PR DESCRIPTION
Previously, the `DFRobot_IICSerial::flush` function would read `fsr` once then get caught in an infinite while loop, potentially triggering WDT. This patch fixes that by continuously reading with a configurable timeout.