### PR TITLE
修改了read(void *pBuf, size_t size)函数溢出问题

### DIFF
--- a/src/DFRobot_IICSerial.cpp
+++ b/src/DFRobot_IICSerial.cpp
@@ -180,10 +180,15 @@ size_t DFRobot_IICSerial::read(void *pBuf, size_t size){
     return 0;
   }
   uint8_t *_pBuf = (uint8_t *)pBuf;
-  size = available() - (((unsigned int)(SERIAL_RX_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail)) % SERIAL_RX_BUFFER_SIZE);
-  readFIFO(_pBuf, size);
-  return size;
+  size_t availableBytes = available() - (
+    ((unsigned int)(SERIAL_RX_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail))
+    % SERIAL_RX_BUFFER_SIZE
+  );
+  size_t toRead = (availableBytes < size) ? availableBytes : size;
+  readFIFO(_pBuf, toRead);
+  return toRead;
 }
+
 void DFRobot_IICSerial::flush(void){
   sFsrReg_t fsr = readFIFOStateReg();
   while(fsr.tDat == 1);


### PR DESCRIPTION
read(void *pBuf, size_t size)函数，忽略了用户穿的size参数，直接把所有收到的数据直接放在用户定义的数组中，容易造成溢出等一系列问题